### PR TITLE
Add frontend sample proposal view

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,23 @@ Currently, Venture's MVP includes the core functionalities necessary for proposa
 ## Getting Started
 
 To start using Venture, simply create an account, input your project details, upload supporting documents, and generate your first proposal. Within minutes, you’ll have a professionally structured, client-ready document designed to impress and convert. Streamline your proposal workflow and focus on closing deals—let Venture handle the rest.
+
+## Local API Example
+
+Run the backend locally to experiment with the API:
+
+1. Install dependencies using `make install`.
+2. Start the server with `make dev-backend`.
+3. Browse to `http://localhost:8000/proposals/sample` to retrieve a sample proposal.
+
+The endpoint returns a JSON document illustrating the structure of generated proposals so you can test integrations before enabling full AI functionality.
+
+
+## Frontend Sample
+
+To preview the proposal design with stub data:
+
+1. In one terminal, run `make dev` to start both backend and frontend.
+2. Visit `http://localhost:3000/sample` in your browser.
+
+The page loads data from `/proposals/sample` and renders it with the React components.

--- a/backend/app/data/sample_proposal.json
+++ b/backend/app/data/sample_proposal.json
@@ -1,0 +1,99 @@
+{
+  "id": "sample-proposal",
+  "createdAt": "2024-03-01T00:00:00Z",
+  "formData": {
+    "projectName": "AI-Ready Knowledge Graph Platform",
+    "clientName": "Client",
+    "industry": "Enterprise",
+    "timeline": "90 days",
+    "budget": "$244k",
+    "objectives": "Unify data sources into knowledge graph",
+    "description": "Enterprise Data Intelligence Solution",
+    "stakeholders": null,
+    "requirements": null
+  },
+  "sections": {
+    "executiveSummary": {
+      "problem": "Enterprise data silos prevent AI initiatives from reaching their full potential, costing organizations millions in lost opportunities.",
+      "opportunity": "A unified knowledge graph platform can unlock 10x faster insights and enable truly intelligent automation across your organization.",
+      "solution": "Custom-built AI-ready platform with graph database core, intelligent APIs, and seamless integration capabilities delivered in 90 days.",
+      "metrics": {
+        "payback": "\u2264 6-month",
+        "savings": "$2.5M",
+        "timeline": "90 days"
+      }
+    },
+    "problemStatement": {
+      "challenges": [
+        "Data scattered across 15+ systems with no unified view",
+        "Manual data integration taking 40+ hours per analysis",
+        "AI models limited by incomplete data relationships"
+      ],
+      "quotes": [
+        {
+          "text": "We're sitting on a goldmine of data but can't mine it effectively. Our AI initiatives are stuck in pilot phase because we can't connect the dots across our systems.",
+          "author": "Chief Data Officer"
+        }
+      ],
+      "impactMetrics": {
+        "cost": "$5M",
+        "efficiency": "60%",
+        "competitive": "2 years"
+      }
+    },
+    "objectives": {
+      "objectives": [
+        "Unify Data Sources: Connect 15+ enterprise systems into single knowledge graph",
+        "Accelerate Insights: Reduce analysis time from 40+ hours to < 2 hours",
+        "Enable AI Excellence: Provide rich context for ML models"
+      ],
+      "kpis": [
+        { "metric": "Query Response Time", "target": "< 200ms", "status": "green" },
+        { "metric": "User Satisfaction (NPS)", "target": "+15 points", "status": "yellow" },
+        { "metric": "Data Integration Speed", "target": "95% faster", "status": "green" }
+      ]
+    },
+    "solution": {
+      "pillars": [
+        { "name": "Intelligent Core", "description": "Graph database with AI-powered relationship discovery and semantic understanding", "icon": "\ud83e\udde0" },
+        { "name": "Universal Connectors", "description": "Pre-built integrations for enterprise systems with real-time synchronization", "icon": "\ud83d\udd17" },
+        { "name": "Insight Engine", "description": "Natural language queries with automated insights and recommendation system", "icon": "\u26a1" }
+      ],
+      "techStrategy": "Custom-built AI-ready platform delivered in 90 days.",
+      "architecture": ["Frontend (React Dashboard)", "API Gateway (GraphQL/REST)", "Graph DB (Neo4j Cluster)"]
+    },
+    "timeline": {
+      "phases": [
+        { "name": "Discovery & Planning", "description": "Requirements gathering, system analysis", "duration": "Week 1-2", "deliverables": [] },
+        { "name": "Core Development", "description": "Graph database setup, API development", "duration": "Week 3-8", "deliverables": [] },
+        { "name": "Integration & Testing", "description": "System connections, performance testing", "duration": "Week 9-11", "deliverables": [] },
+        { "name": "Deployment & Launch", "description": "Production deployment, user training", "duration": "Week 12-13", "deliverables": [] }
+      ]
+    },
+    "team": {
+      "members": [
+        { "name": "Jane Doe", "role": "Technical Lead", "expertise": "Graph database expert with 10+ years experience", "initials": "JD" },
+        { "name": "Mike Smith", "role": "Full-Stack Developer", "expertise": "API architecture and frontend specialist", "initials": "MS" },
+        { "name": "Sarah Johnson", "role": "AI Engineer", "expertise": "Machine learning and natural language processing", "initials": "SJ" },
+        { "name": "Alex Brown", "role": "Project Manager", "expertise": "Agile delivery and stakeholder management", "initials": "AB" }
+      ]
+    },
+    "budget": {
+      "breakdown": [
+        { "category": "Development (720 hours)", "amount": 144000, "description": "" },
+        { "category": "Infrastructure & Licenses", "amount": 36000, "description": "" },
+        { "category": "Testing & QA", "amount": 24000, "description": "" },
+        { "category": "Project Management", "amount": 18000, "description": "" },
+        { "category": "Contingency (10%)", "amount": 22200, "description": "" }
+      ],
+      "total": 244200,
+      "paymentSchedule": [
+        { "milestone": "Project Kickoff", "percentage": 25, "amount": 61050, "timing": "Week 1" },
+        { "milestone": "MVP Delivery", "percentage": 30, "amount": 73260, "timing": "Week 6" },
+        { "milestone": "Beta Release", "percentage": 25, "amount": 61050, "timing": "Week 10" },
+        { "milestone": "Final Delivery", "percentage": 20, "amount": 48840, "timing": "Week 13" }
+      ]
+    }
+  },
+  "markdown": ""
+}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ except Exception:  # pragma: no cover
 try:
     from pdfminer.high_level import extract_text  # type: ignore
 except Exception:  # pragma: no cover
+
     def extract_text(_):
         return ""
 
@@ -72,7 +73,9 @@ class UploadResponse(BaseModel):
 
 
 @app.post("/files/upload")
-async def upload_files(files: List[UploadFile] = File(...)) -> Dict[str, UploadResponse]:
+async def upload_files(
+    files: List[UploadFile] = File(...),
+) -> Dict[str, UploadResponse]:
     if not files:
         raise HTTPException(status_code=400, detail="No files uploaded")
 
@@ -109,7 +112,10 @@ async def upload_files(files: List[UploadFile] = File(...)) -> Dict[str, UploadR
             )
         )
 
-    return {"success": True, "data": UploadResponse(fileIds=[u.id for u in uploaded], files=uploaded)}
+    return {
+        "success": True,
+        "data": UploadResponse(fileIds=[u.id for u in uploaded], files=uploaded),
+    }
 
 
 class GenerateRequest(FormData):
@@ -186,6 +192,17 @@ async def get_proposal(proposal_id: str) -> Proposal:
     if not os.path.exists(path):
         raise HTTPException(status_code=404, detail="Proposal not found")
     with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return Proposal(**data)
+
+
+@app.get("/proposals/sample")
+async def get_sample_proposal() -> Proposal:
+    """Return a static sample proposal for testing."""
+    sample_path = os.path.join(
+        os.path.dirname(__file__), "data", "sample_proposal.json"
+    )
+    with open(sample_path, "r", encoding="utf-8") as f:
         data = json.load(f)
     return Proposal(**data)
 

--- a/frontend/app/sample/page.tsx
+++ b/frontend/app/sample/page.tsx
@@ -1,0 +1,27 @@
+import ProposalContent from "@/components/ProposalContent"
+import { Proposal } from "@/app/lib/types"
+
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8000'
+
+async function getSampleProposal(): Promise<Proposal | null> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/proposals/sample`)
+    if (!res.ok) {
+      return null
+    }
+    return (await res.json()) as Proposal
+  } catch (err) {
+    console.error('Error loading sample proposal:', err)
+    return null
+  }
+}
+
+export default async function SamplePage() {
+  const proposal = await getSampleProposal()
+
+  if (!proposal) {
+    return <div className="p-8 text-center">Unable to load sample proposal.</div>
+  }
+
+  return <ProposalContent proposal={proposal} />
+}


### PR DESCRIPTION
## Summary
- expand `sample_proposal.json` with realistic data for all sections
- create Next.js page at `/sample` that renders the sample proposal
- document how to view the sample frontend page

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684336609cc48331a4fa588fa649d856